### PR TITLE
Replace the underscore by h

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -47,7 +47,7 @@ export default function () {
     if (figma.currentPage.selection.length > 0) {
       const node = figma.currentPage.selection[0];
       const regexName = /[^a-zA-Z0-9]+/g;
-      const newName = node.name.replace(regexName, "_").toLowerCase();
+      const newName = node.name.replace(regexName, "-").toLowerCase();
 
       emit<SelectionChanged>(
         "SELECTION_CHANGED",


### PR DESCRIPTION
Hi Tobias !

Thank you for this very cool tool, I use everyday !

When you format file name, I think you should replace underscore by hyphens or let the user choose. Here is why :
 
> In regards to SEO, by providing search engines with textual information for images, your site will benefit from both better placement in search returns and improved positioning in image search results. Remember to use hyphens rather than underscores to separate words.

Source : https://www.winthrop.edu/web/file-naming.aspx#:~:text=In%20regards%20to%20SEO%2C%20by,than%20underscores%20to%20separate%20words.

Thank you very much,
Have fun building in open source !